### PR TITLE
Add support for capacity provider strategy attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Runs an Amazon ECS task on ECS cluster.
         count: 1
         started-by: github-actions-${{ github.actor }}
         wait-for-finish: true
+        capacity-provider-strategy: '[{"capacityProvider": "provider", "base": 1, "weight": 1}]' # optional
 ```
 
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   wait-for-minutes:
     description: 'How long to wait for the task reach stopped state, in minutes (default: 30 minutes, max: 6 hours).'
     required: false
+  capacity-provider-strategy:
+    description: "JSON representation of the capacity provider strategy to use for the task."
+    required: false
 outputs:
   task-definition-arn:
     description: 'The ARN of the registered ECS task definition'


### PR DESCRIPTION
Add support for optional `capacityProviderStrategy` attribute for `runTask` command: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/ECS.html#runTask-property

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
